### PR TITLE
test: allow existing sm to be passed in api example

### DIFF
--- a/examples/api_key_auth/variables.tf
+++ b/examples/api_key_auth/variables.tf
@@ -29,6 +29,18 @@ variable "resource_group" {
   default     = null
 }
 
+variable "existing_sm_instance_crn" {
+  type        = string
+  description = "Existing Secrets Manager CRN. If not provided a new instance will be provisioned"
+  default     = null
+}
+
+variable "existing_sm_instance_region" {
+  type        = string
+  description = "Existing Secrets Manager Region. Required if value is passed into var.existing_sm_instance_name"
+  default     = null
+}
+
 variable "cis_id" {
   type        = string
   description = "Cloud Internet Service ID"

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -46,6 +46,8 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 			"private_key_secrets_manager_instance_guid": permanentResources["acme_letsencrypt_private_key_sm_id"],
 			"private_key_secrets_manager_secret_id":     permanentResources["acme_letsencrypt_private_key_secret_id"],
 			"private_key_secrets_manager_region":        permanentResources["acme_letsencrypt_private_key_sm_region"],
+			"existing_sm_instance_guid":                 permanentResources["secretsManagerGuid"],
+			"existing_sm_instance_region":               permanentResources["secretsManagerRegion"],
 		},
 		BestRegionYAMLPath: bestRegionYAMLPath,
 	})


### PR DESCRIPTION
### Description

A private only example already exists in this repo, so it was just adjusted to allow for an existing secrets manager to be passed in and the test adjusted to use our permanent private only secrets manager.

Git Issue: https://github.com/terraform-ibm-modules/terraform-ibm-secrets-manager-public-cert-engine/issues/73

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
